### PR TITLE
Initialize decoded objects to 0.

### DIFF
--- a/static/cauterize.c
+++ b/static/cauterize.c
@@ -164,6 +164,15 @@ S schema_decode_iterator_init(SDI * si, SD const * sd, TDI * ti, size_t ti_count
         .dst_type = dst_type,
     };
 
+    // Initialize the object memory to 0. The decoder assumes that it
+    // only has to overlay bytes on top of a 0'ed out object. If this
+    // is not here, then situations where tags on the host are wider
+    // than the encoded tags may result in garbage values stored in
+    // the host tag.
+    TD const * td = NULL;
+    RE(get_type_desc(sd, type_id, &td));
+    memset(dst_type, 0, td->obj_size);
+
     RE(type_decode_iterator_init(sd, ti, type_id, dst_type));
 
     return caut_status_ok;


### PR DESCRIPTION
This isn't as elegant as it could be, but it's more correct. Objects that use tags like enumerations have sizes that are dependent on the platform and compiler. This information _currently_ isn't captured anywhere in the generated code.

Another approach would be to store the size of the tag on each individual object in the type descriptor (since some compilers will optimize enumeration sizes based on the number of members) or zero out all the bytes that come before fields on objects with tags before copying in the tag bytes.

For now, this approach doesn't change the main state machine and does fix a bug observed by @pchickey.

Future work could have the state machine find a way to only set those bytes to 0 that need to be set (avoiding the `memset` we add here).