### PR TITLE
Add Travis CI config to project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+# This informs travis to use a docker container
+sudo: false
+
+# Since we're using a container, we can cache specified directories
+# Specifally, let's cache haskell-stack related stuff since it's slow to rebuild
+cache:
+  directories:
+  - $HOME/.stack
+
+# Just use `c` since we're going to download the Haskell compiler (GHC) via stack
+language: c
+
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - gcc-4.7
+            - libgmp3-dev
+      env: COMPILER=gcc-4.7
+    - compiler: clang
+      addons:
+        apt:
+          packages:
+            - libgmp3-dev
+      env: COMPILER=clang
+
+before_install:
+  - mkdir -p ~/.local/bin
+  - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+  - stack setup
+
+script:
+  - make
+  - sh run_crucible.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
+[![Build Status](https://travis-ci.org/cauterize-tools/caut-c11-stream.svg?branch=master)](https://travis-ci.org/cauterize-tools/caut-c11-stream)
+
 # caut-c11-stream

--- a/run_crucible.sh
+++ b/run_crucible.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+COMPILER="${COMPILER:-cc}"
+
 stack exec crucible -- tester \
   --build-cmd="stack exec caut-c11-stream -- genall %s c11" \
-  --build-cmd="cd c11 && ls *.c && clang -Os -Wall -Wextra -std=c11 -pedantic *.c -o test_client" \
+  --build-cmd="cd c11 && ls *.c && $COMPILER -Os -Wall -Wextra -std=c11 -pedantic *.c -o test_client" \
   --run-cmd="./c11/test_client" \
   --schema-count=1 \
   --instance-count=1000 \


### PR DESCRIPTION
I confirmed this works with [my account](https://travis-ci.org/JayKickliter/caut-c11-stream/). Someone from the `cauterize-tools` org will have to enable builds for this repo at [travis-ci.org](travis-ci.org).